### PR TITLE
Error Handling and Updated Session Management

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -77,10 +77,12 @@ function App() {
           setSpotifyToken(lastJsonMessage.token);
           break;
         case 'error': // Error from backend
+          setMessageHistory((prev) => [...prev, ['Server', lastJsonMessage.error]]);
           console.error(lastJsonMessage.error);
           break;
         default:
-          console.error('Unsupported message type');
+          setMessageHistory((prev) => [...prev, ['App', 'Error: Unsupported message type']]);
+          console.error('Error: Unsupported message type');
       }
     }
   }, [lastJsonMessage]);

--- a/src/App.js
+++ b/src/App.js
@@ -70,9 +70,11 @@ function App() {
         setMessageHistory((prev) => [...prev, ['Server', lastJsonMessage.message]]);
       } else if (lastJsonMessage.type === 'user-info') {
         setUsername(lastJsonMessage.username);
-        setProfilePic(lastJsonMessage.profile_pic);
+        if ('profile_pic' in lastJsonMessage) setProfilePic(lastJsonMessage.profile_pic);
       } else if (lastJsonMessage.type === 'spotify-token') {
         setSpotifyToken(lastJsonMessage.token);
+      } else if (lastJsonMessage.type === 'error') {
+        console.log(lastJsonMessage.error)
       }
     }
   }, [lastJsonMessage]);

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,114 @@
-
-import React from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Route, Routes } from "react-router-dom";
+import useWebSocket, { ReadyState } from 'react-use-websocket';
+import axios from 'axios';
+import { useCookies } from 'react-cookie';
 
 import './App.css';
+import Layout from "./Layout"
 import Login from "./Login";
 import Dashboard from "./Dashboard";
 
+const socketUrl = 'ws://localhost:8000/';
+
 function App() {
+  const [cookies, setCookies] = useCookies(['user']);
+  const [username, setUsername] = useState();
+  const [profilePic, setProfilePic] = useState();
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [spotifyToken, setSpotifyToken] = useState();
+  const [messageHistory, setMessageHistory] = useState([['App', 'Started']]);
+
+  useEffect(() => {
+    const checkSession = async (interval) => {
+      if (cookies.state !== undefined) {
+        axios.get('http://localhost:8000/' + cookies.state + '/session-valid')
+          .then(function (response) {
+            if (response.status === 200) {
+              setLoggedIn(true);
+            } else {
+              console.log(response);
+            }
+          })
+          .catch(function (error) {
+            if (error.response.status === 404) {
+              setUsername();
+              setProfilePic();
+              setSpotifyToken();
+              clearInterval(interval);
+            }
+            setLoggedIn(false);
+            console.log(error);
+          });
+      }
+    }
+    const interval = setInterval(() => { checkSession(interval); }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const getSocketUrl = useCallback(() => {
+    return new Promise((resolve) => {
+      (function waitForLogin() {
+        if (loggedIn) {
+          resolve(socketUrl + cookies.state + '/ws');
+        }
+        setTimeout(waitForLogin, 30);
+      })();
+    });
+  }, [loggedIn]);
+
+  const { sendMessage, lastJsonMessage, readyState } = useWebSocket(getSocketUrl, {
+    onOpen: () => {
+      setMessageHistory((prev) => [...prev, ['App', 'Connected to ' + socketUrl]]);
+    },
+  });
+
+  // called when last json message changes, so anytime the backend sends a message.
+  useEffect(() => {
+    if (lastJsonMessage !== null) {
+      if (lastJsonMessage.type === 'message') { // if message type json, add to message history
+        setMessageHistory((prev) => [...prev, ['Server', lastJsonMessage.message]]);
+      } else if (lastJsonMessage.type === 'user-info') {
+        setUsername(lastJsonMessage.username);
+        setProfilePic(lastJsonMessage.profile_pic);
+      } else if (lastJsonMessage.type === 'spotify-token') {
+        setSpotifyToken(lastJsonMessage.token);
+      }
+    }
+  }, [lastJsonMessage]);
+
+  // button function that gets the auth url from backend and redirects to it
+  const spotifyLogin = () => {
+    axios.get('http://localhost:8000/spotify-login')
+      .then(function (response) {
+        setCookies('state', response.data.state);
+        window.location.href = response.data.auth_url;
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+
+  const logout = () => {
+    axios.post('http://localhost:8000/' + cookies.state + '/session-logout')
+      .then(function () {
+        setCookies('state', undefined);
+        setUsername();
+        setProfilePic();
+        setSpotifyToken();
+        setLoggedIn(false);
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+
   return (
     <Routes>
-      <Route path="/" element={<Login />} />
-      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/" element={<Layout username={username} profilePic={profilePic} spotifyLogin={spotifyLogin} logout={logout} loggedIn={loggedIn} />}>
+        <Route index element={<Login spotifyLogin={spotifyLogin} />} />
+        <Route path="dashboard" element={<Dashboard sendMessage={sendMessage} readyState={readyState} messageHistory={messageHistory} setMessageHistory={setMessageHistory} spotifyToken={spotifyToken} />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/Dashboard.css
+++ b/src/Dashboard.css
@@ -1,6 +1,21 @@
 .Dashboard {
+  position: relative;
   overflow: hidden;
   height: 88vh;
+}
+
+.Overlay {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: xx-large;
+  color: white;
+  width: 100%;
+  height: 88vh;
+  background-color: rgba(0, 0, 0, 0.65);
+  top: 0%;
+  bottom: 0%;
 }
 
 .MessageHistory {

--- a/src/Dashboard.css
+++ b/src/Dashboard.css
@@ -1,6 +1,6 @@
 .Dashboard {
   overflow: hidden;
-  height: 100vh;
+  height: 88vh;
 }
 
 .MessageHistory {

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,17 +1,19 @@
 import React, { useEffect, useState } from "react";
-import useWebSocket, { ReadyState } from 'react-use-websocket';
+import { ReadyState } from 'react-use-websocket';
+import { useOutletContext } from "react-router-dom";
 
 import WebPlayer from "./WebPlayer";
 import './Dashboard.css';
 
 function Dashboard(props) {
   let messagesEnd;
+  const loggedIn = useOutletContext(); // Get loggedIn from layout
   const [currentMessage, setCurrentMessage] = useState('');
 
   // scroll to messages end whenever a new message is added
   useEffect(() => {
     messagesEnd.scrollIntoView({ behavior: "smooth" });
-  }, [props.messageHistory, messagesEnd]); //messages end is only added to suppress eslint warning
+  }, [props.messageHistory, messagesEnd]); // messages end is only added to suppress eslint warning
 
   // prevents empty messages from being sent, after sending clear current message
   const handleSend = () => {
@@ -40,6 +42,7 @@ function Dashboard(props) {
 
   return (
     <div className="Dashboard">
+      {!loggedIn && <div className="Overlay">Not Logged In</div>}
       <div className="MessageHistory">
         {props.messageHistory.map((message, idx) => (
           <div className="Message" key={idx}><div className="MessageUser">{message[0]}</div><div className="MessageText">{message[1] ? message[1] : null}</div></div>

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,52 +1,23 @@
 import React, { useEffect, useState } from "react";
 import useWebSocket, { ReadyState } from 'react-use-websocket';
-import { useCookies } from 'react-cookie';
 
-import Header from './Header';
 import WebPlayer from "./WebPlayer";
 import './Dashboard.css';
-const socketUrl = 'ws://localhost:8000/';
 
-function Dashboard() {
-  const [cookies, setCookies] = useCookies(['user']);
-  const [spotifyToken, setSpotifyToken] = useState();
-  const [username, setUsername] = useState();
-  const [profilePic, setProfilePic] = useState();
-  const [currentMessage, setCurrentMessage] = useState('');
-  const [messageHistory, setMessageHistory] = useState([['App', 'Started']]);
+function Dashboard(props) {
   let messagesEnd;
-  const userUrl = socketUrl + cookies.state + '/ws';
-
-  const { sendMessage, lastJsonMessage, readyState } = useWebSocket(userUrl, {
-    onOpen: () => {
-      setMessageHistory((prev) => [...prev, ['App', 'Connected to ' + socketUrl]]);
-    }
-  });
-
-  // called when last json message changes, so anytime the backend sends a message.
-  useEffect(() => {
-    if (lastJsonMessage !== null) {
-      if (lastJsonMessage.type === 'message') { // if message type json, add to message history
-        setMessageHistory((prev) => [...prev, ['Server', lastJsonMessage.message]]);
-      } else if (lastJsonMessage.type === 'user-info') { // if user info type, update state user info
-        setUsername(lastJsonMessage.username);
-        setProfilePic(lastJsonMessage.profile_pic);
-      } else if (lastJsonMessage.type === 'spotify-token') {
-        setSpotifyToken(lastJsonMessage.token);
-      }
-    }
-  }, [lastJsonMessage]);
+  const [currentMessage, setCurrentMessage] = useState('');
 
   // scroll to messages end whenever a new message is added
   useEffect(() => {
     messagesEnd.scrollIntoView({ behavior: "smooth" });
-  }, [messageHistory, messagesEnd]); //messages end is only added to suppress eslint warning
+  }, [props.messageHistory, messagesEnd]); //messages end is only added to suppress eslint warning
 
   // prevents empty messages from being sent, after sending clear current message
   const handleSend = () => {
     if (currentMessage !== '') {
-      sendMessage(currentMessage);
-      setMessageHistory((prev) => [...prev, ['User', currentMessage]]);
+      props.sendMessage(currentMessage);
+      props.setMessageHistory((prev) => [...prev, ['User', currentMessage]]);
       setCurrentMessage('');
     }
   }
@@ -58,7 +29,7 @@ function Dashboard() {
     [ReadyState.CLOSING]: 'Closing',
     [ReadyState.CLOSED]: 'Closed',
     [ReadyState.UNINSTANTIATED]: 'Uninstantiated',
-  }[readyState];
+  } [props.readyState];
 
   // function to send message when enter is pressed when focused on the input box
   const enterPress = (event) => {
@@ -69,9 +40,8 @@ function Dashboard() {
 
   return (
     <div className="Dashboard">
-      <Header username={username} profilePic={profilePic} />
       <div className="MessageHistory">
-        {messageHistory.map((message, idx) => (
+        {props.messageHistory.map((message, idx) => (
           <div className="Message" key={idx}><div className="MessageUser">{message[0]}</div><div className="MessageText">{message[1] ? message[1] : null}</div></div>
         ))}
         <div ref={(el) => { messagesEnd = el; }}></div>
@@ -81,7 +51,7 @@ function Dashboard() {
         <button onClick={handleSend}>Send</button>
       </div>
       <div className="StatusBar">Connection Status: {connectionStatus}</div>
-      <WebPlayer token={spotifyToken} />
+      <WebPlayer token={props.spotifyToken} />
     </div>
   );
 }

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -5,8 +5,11 @@ import { useOutletContext } from "react-router-dom";
 import WebPlayer from "./WebPlayer";
 import './Dashboard.css';
 
+// Dashboard page that displays chatbot chat and web player.
+// Props are provided from app, given readyState and messageHistory to display messages and connection info,
+// given sendMessage to send users current message, and given spotify token for the web player.
 function Dashboard(props) {
-  let messagesEnd;
+  let messagesEnd; // variable for end of messages displayed in message history
   const loggedIn = useOutletContext(); // Get loggedIn from layout
   const [currentMessage, setCurrentMessage] = useState('');
 
@@ -42,15 +45,20 @@ function Dashboard(props) {
 
   return (
     <div className="Dashboard">
+      {/* Overlay div if user is not logged in */}
       {!loggedIn && <div className="Overlay">Not Logged In</div>}
       <div className="MessageHistory">
+        {/* render all messages in message history */}
         {props.messageHistory.map((message, idx) => (
           <div className="Message" key={idx}><div className="MessageUser">{message[0]}</div><div className="MessageText">{message[1] ? message[1] : null}</div></div>
         ))}
+        {/* Set div at end of message to messages end */}
         <div ref={(el) => { messagesEnd = el; }}></div>
       </div>
       <div className="MessageBox">
-        <div className="MessageLabel">Message:</div><input type="text" value={currentMessage} onKeyDown={(e) => enterPress(e)} onChange={message => { setCurrentMessage(message.target.value) }} />
+        <div className="MessageLabel">Message:</div>
+        {/* message input box, check for keydown enter and set current message on change */}
+        <input type="text" value={currentMessage} onKeyDown={(e) => enterPress(e)} onChange={message => { setCurrentMessage(message.target.value) }} />
         <button onClick={handleSend}>Send</button>
       </div>
       <div className="StatusBar">Connection Status: {connectionStatus}</div>

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -34,7 +34,7 @@ function Dashboard(props) {
     [ReadyState.CLOSING]: 'Closing',
     [ReadyState.CLOSED]: 'Closed',
     [ReadyState.UNINSTANTIATED]: 'Uninstantiated',
-  } [props.readyState];
+  }[props.readyState];
 
   // function to send message when enter is pressed when focused on the input box
   const enterPress = (event) => {

--- a/src/Header.js
+++ b/src/Header.js
@@ -3,15 +3,17 @@ import { Link } from "react-router-dom";
 
 import './Header.css';
 
+// Header component for all pages in app, takes in props from layout (log in and out functions, user info) and displays them.
 function Header(props) {
-
     // TODO: Fix prof pic css to look good for width>height images
     return (
         <div className="Header">
             <Link to="/"><h1>Spotify Chatbot</h1></Link>
             <div className='UserCard'>
+                {/* Show log in or out when needed, displays username and profile pic if available, defaults if not */}
                 {props.loggedIn ? <button onClick={props.logout}>Log Out</button> : <button onClick={props.spotifyLogin}>Log In</button>}
                 <p>{props.username || 'No User'}</p>
+                {/* Cropper div to make pic a circle and centered */}
                 <div className="ProfilePicCropper">
                     <img className="ProfilePic" src={props.profilePic || '/blank-profile-picture.png'}></img>
                 </div>

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,4 +1,6 @@
-import React from 'react'
+import React from 'react';
+import { Link } from "react-router-dom";
+
 import './Header.css';
 
 function Header(props) {
@@ -6,8 +8,9 @@ function Header(props) {
     // TODO: Fix prof pic css to look good for width>height images
     return (
         <div className="Header">
-            <a href="/"><h1>Spotify Chatbot</h1></a>
+            <Link to="/"><h1>Spotify Chatbot</h1></Link>
             <div className='UserCard'>
+                {props.loggedIn ? <button onClick={props.logout}>Log Out</button> : <button onClick={props.spotifyLogin}>Log In</button>}
                 <p>{props.username || 'No User'}</p>
                 <div className="ProfilePicCropper">
                     <img className="ProfilePic" src={props.profilePic || '/blank-profile-picture.png'}></img>

--- a/src/Header.js
+++ b/src/Header.js
@@ -7,15 +7,15 @@ import './Header.css';
 function Header(props) {
     // TODO: Fix prof pic css to look good for width>height images
     return (
-        <div className="Header">
-            <Link to="/"><h1>Spotify Chatbot</h1></Link>
+        <div className='Header'>
+            <Link to='/'><h1>Spotify Chatbot</h1></Link>
             <div className='UserCard'>
                 {/* Show log in or out when needed, displays username and profile pic if available, defaults if not */}
                 {props.loggedIn ? <button onClick={props.logout}>Log Out</button> : <button onClick={props.spotifyLogin}>Log In</button>}
                 <p>{props.username || 'No User'}</p>
                 {/* Cropper div to make pic a circle and centered */}
-                <div className="ProfilePicCropper">
-                    <img className="ProfilePic" src={props.profilePic || '/blank-profile-picture.png'}></img>
+                <div className='ProfilePicCropper'>
+                    <img className='ProfilePic' alt='Profile Avatar' src={props.profilePic || '/blank-profile-picture.png'}></img>
                 </div>
             </div>
         </div>

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -3,6 +3,8 @@ import { Outlet } from "react-router-dom";
 
 import Header from './Header';
 
+// Simple layout component for all pages, puts header at top and rest of page below.
+// Gets props from app, passes if logged in to all outlets.
 function Layout(props) {
     return (
         <div>

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+
+import Header from './Header';
+
+function Layout(props) {
+    return (
+        <div>
+            <Header username={props.username} profilePic={props.profilePic} spotifyLogin={props.spotifyLogin} logout={props.logout} loggedIn={props.loggedIn}/>
+            <Outlet context={props.loggedIn} />
+        </div>
+    );
+}
+
+export default Layout;

--- a/src/Login.css
+++ b/src/Login.css
@@ -1,4 +1,7 @@
 .Login {
-    text-align: center;
-  }
-  
+  text-align: center;
+}
+
+.ErrorText {
+  color: red;
+}

--- a/src/Login.js
+++ b/src/Login.js
@@ -4,11 +4,13 @@ import { useSearchParams } from "react-router-dom";
 
 import './Login.css';
 
+// Login page that has info on the project and a link to dashboard or to login.
 function Login(props) {
-  const loggedIn = useOutletContext();
+  const loggedIn = useOutletContext(); // Get loggedIn from layout
   const [searchParams] = useSearchParams();
   const [error, setError] = useState('');
 
+  // Checks and sets if there is an error in the params
   useEffect(() => {
     let errorCode = searchParams.get('error');
     if (errorCode !== null) {

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,33 +1,28 @@
-import React from "react";
-import axios from 'axios';
-import { useCookies } from 'react-cookie';
-
-import Header from "./Header";
+import React, { useEffect, useState } from "react";
+import { Link, useOutletContext } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 import './Login.css';
 
-function Login() {
-  const [cookie, setCookies] = useCookies(['user']);
+function Login(props) {
+  const loggedIn = useOutletContext();
+  const [searchParams] = useSearchParams();
+  const [error, setError] = useState('');
 
-    // button function that gets the auth url from backend and redirect to it
-    const spotifyLogin = () => {
-      axios.get('http://localhost:8000/spotify-login')
-        .then(function (response) {
-          setCookies('state', response.data.state);
-          window.location.href = response.data.auth_url;
-        })
-        .catch(function (error) {
-          console.log(error);
-        });
+  useEffect(() => {
+    let errorCode = searchParams.get('error');
+    if (errorCode !== null) {
+      setError('Error: (' + errorCode + ') Please try to login again.');
     }
-  
-    return (
-      <div className="Login">
-        <Header />
-        <p>A chatbot that can predict what songs the user wants to listen to based on their location as well as both explicit input + analysis of users mood</p>
-        <button onClick={spotifyLogin}>Login with Spotify</button>
-      </div>
-    );
-  }
-  
-  export default Login;
+  }, [searchParams]);
+
+  return (
+    <div className="Login">
+      <p>A chatbot that can predict what songs the user wants to listen to based on their location as well as both explicit input + analysis of users mood</p>
+      <p className="ErrorText">{error}</p>
+      { loggedIn ? <Link to="/dashboard"><button>Go to Dashboard</button></Link> : <button onClick={props.spotifyLogin}>Login with Spotify</button>}
+    </div>
+  );
+}
+
+export default Login;

--- a/src/Login.js
+++ b/src/Login.js
@@ -22,6 +22,7 @@ function Login(props) {
     <div className="Login">
       <p>A chatbot that can predict what songs the user wants to listen to based on their location as well as both explicit input + analysis of users mood</p>
       <p className="ErrorText">{error}</p>
+      {/* Display dashboard link or log in button depending on logged in state */}
       { loggedIn ? <Link to="/dashboard"><button>Go to Dashboard</button></Link> : <button onClick={props.spotifyLogin}>Login with Spotify</button>}
     </div>
   );

--- a/src/WebPlayer.js
+++ b/src/WebPlayer.js
@@ -102,7 +102,7 @@ function WebPlayer({ token }) {
                 <div>{currentTrack || 'No Song Playing'}</div>
                 <div>{currentArtist || 'No Artist'}</div>
                 <div>{msToMinSec(currentTrackProgress)}/{msToMinSec(currentTrackLength)}</div>
-                {/* If not active grey out buttons and let user know, display pause or play when relevant */}
+                {/* If not active grey out buttons and show not active message, display pause or play when relevant */}
                 <div className={`${isActive ? 'ControlButtons' : 'ControlButtonsLight'}`}>
                     <img src='/previous-button.svg' alt='Previous Song' onClick={previousSong}></img>
                     <img src={`${isPlaying ? '/pause-button.svg' : '/play-button.svg'}`} alt='Play or Pause' onClick={playPauseSong}></img>

--- a/src/WebPlayer.js
+++ b/src/WebPlayer.js
@@ -3,6 +3,9 @@ import axios from 'axios';
 
 import './WebPlayer.css';
 
+// Component that is displayed on the dashboard, shows the album cover, song name, artist name,
+// and song time for current playback. Gives user playback control with buttons that are enabled when active.
+// Receives token as a prop for spotify playback requests.
 function WebPlayer({ token }) {
     const [isPlaying, setPlaying] = useState(false);
     const [isActive, setActive] = useState(false);
@@ -12,94 +15,94 @@ function WebPlayer({ token }) {
     const [currentTrackLength, setTrackLength] = useState(0);
     const [currentTrackProgress, setTrackProgress] = useState(0);
 
+    // Whenever token is changed, create an interval to update the playback every second
     useEffect(() => {
-        const updatePlayback = async () => {
-            if (token !== undefined) {
-                const config = {
-                    headers: {
-                        'Authorization': 'Bearer ' + token,
-                        'Content-Type': 'application/json'
-                    }
-                };
-                axios.get('https://api.spotify.com/v1/me/player/currently-playing', config).then(function (response) {
-                    if (response.status === 200) {
-                        setTrack(response.data.item.name);
-                        setArtist(response.data.item.artists[0].name);
-                        setAlbumArt(response.data.item.album.images[0].url);
-                        setPlaying(response.data.is_playing);
-                        setTrackProgress(response.data.progress_ms);
-                        setTrackLength(response.data.item.duration_ms);
-                        setActive(true);
-                    } else {
-                        setActive(false);
-                    }
-                }).catch(function (error) {
-                    console.log(error);
-                    setActive(false);
-                });
-            } else {
-                setActive(false);
-            }
-        };
         const interval = setInterval(() => { updatePlayback(); }, 1000);
         return () => clearInterval(interval);
     }, [token]);
 
-    const playPauseSong = async () => {
-        const config = {
+    // Function to generate user header for various spotify requests
+    const getUserHeader = () => {
+        return {
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
             }
         };
-        if (isPlaying) {
+    }
+
+    // Function that will updated the playback info in the component, requests spotify and sets active status.
+    const updatePlayback = () => {
+        if (token !== undefined) { // Only request if there is a token
+            const config = getUserHeader();
+            axios.get('https://api.spotify.com/v1/me/player/currently-playing', config).then(function (response) {
+                // If playback request is valid, set state. Otherwise set inactive
+                if (response.status === 200) { // Check if playback is active, is 204 if not
+                    setTrack(response.data.item.name);
+                    setArtist(response.data.item.artists[0].name);
+                    setAlbumArt(response.data.item.album.images[0].url);
+                    setPlaying(response.data.is_playing);
+                    setTrackProgress(response.data.progress_ms);
+                    setTrackLength(response.data.item.duration_ms);
+                    setActive(true);
+                } else {
+                    setActive(false);
+                }
+            }).catch(function (error) {
+                setActive(false);
+                console.error(error);
+            });
+        } else {
+            setActive(false);
+        }
+    };
+
+    // button function to play or pause the current song
+    const playPauseSong = () => {
+        const config = getUserHeader();
+        if (isPlaying) { // If playing, pause the song. If paused, play.
             axios.put('https://api.spotify.com/v1/me/player/pause', {}, config).catch(function (error) {
-                console.log('Error pausing song: ' + error);
+                console.error('Error pausing song: ' + error);
             });
         } else {
             axios.put('https://api.spotify.com/v1/me/player/play', {}, config).catch(function (error) {
-                console.log('Error playing song: ' + error);
+                console.error('Error playing song: ' + error);
             });
         }
     }
 
-    const previousSong = async () => {
-        const config = {
-            headers: {
-                'Authorization': 'Bearer ' + token,
-                'Content-Type': 'application/json'
-            }
-        };
+    // button function to play previous song
+    const previousSong = () => {
+        const config = getUserHeader();
         axios.post('https://api.spotify.com/v1/me/player/previous', {}, config).catch(function (error) {
-            console.log('Error previous song: ' + error);
+            console.error('Error previous song: ' + error);
         });
     }
 
-    const nextSong = async () => {
-        const config = {
-            headers: {
-                'Authorization': 'Bearer ' + token,
-                'Content-Type': 'application/json'
-            }
-        };
+    // button function to play next song
+    const nextSong = () => {
+        const config = getUserHeader();
         axios.post('https://api.spotify.com/v1/me/player/next', {}, config).catch(function (error) {
-            console.log('Error next song: ' + error);
+            console.error('Error next song: ' + error);
         });
     }
 
+    // function that takes in a number of milliseconds and returns a equivalent string of the mins and secs
     const msToMinSec = (ms) => {
         const secs = Math.floor((ms / 1000) % 60);
         const mins = Math.floor((ms / 1000 / 60) % 60);
-        return (secs === 60) ? (mins + 1) + ":00" : mins + ":" + (secs < 10 ? "0" : "") + secs;
+        return (secs === 60) ? (mins + 1) + ":00" : mins + ":" + (secs < 10 ? "0" : "") + secs; // Check so 59 secs is limit
     };
 
     return (
         <div className='WebPlayer'>
+            {/* If state is set display it, if not display default art, track, artist */}
             <img className='AlbumArt' src={currentAlbumArt || '/blank-album-art.png'} alt='Album Art'></img>
             <div>
                 <div>{currentTrack || 'No Song Playing'}</div>
                 <div>{currentArtist || 'No Artist'}</div>
                 <div>{msToMinSec(currentTrackProgress)}/{msToMinSec(currentTrackLength)}</div>
+                {/* If not active grey out buttons and let user know, display pause or play when relevant */}
                 <div className={`${isActive ? 'ControlButtons' : 'ControlButtonsLight'}`}>
                     <img src='/previous-button.svg' alt='Previous Song' onClick={previousSong}></img>
                     <img src={`${isPlaying ? '/pause-button.svg' : '/play-button.svg'}`} alt='Play or Pause' onClick={playPauseSong}></img>

--- a/src/WebPlayer.js
+++ b/src/WebPlayer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 
 import './WebPlayer.css';
@@ -15,24 +15,18 @@ function WebPlayer({ token }) {
     const [currentTrackLength, setTrackLength] = useState(0);
     const [currentTrackProgress, setTrackProgress] = useState(0);
 
-    // Whenever token is changed, create an interval to update the playback every second
-    useEffect(() => {
-        const interval = setInterval(() => { updatePlayback(); }, 1000);
-        return () => clearInterval(interval);
-    }, [token]);
-
     // Function to generate user header for various spotify requests
-    const getUserHeader = () => {
+    const getUserHeader = useCallback(() => {
         return {
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
             }
         };
-    }
+    }, [token]);
 
     // Function that will updated the playback info in the component, requests spotify and sets active status.
-    const updatePlayback = () => {
+    const updatePlayback = useCallback(() => {
         if (token !== undefined) { // Only request if there is a token
             const config = getUserHeader();
             axios.get('https://api.spotify.com/v1/me/player/currently-playing', config).then(function (response) {
@@ -55,7 +49,13 @@ function WebPlayer({ token }) {
         } else {
             setActive(false);
         }
-    };
+    }, [token, getUserHeader]);
+
+    // Whenever token is changed, create an interval to update the playback every second
+    useEffect(() => {
+        const interval = setInterval(() => { updatePlayback(); }, 1000);
+        return () => clearInterval(interval);
+    }, [token, updatePlayback]);
 
     // button function to play or pause the current song
     const playPauseSong = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -8,6 +7,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = createRoot(document.getElementById("root"));
 
+// Index for application to start at, makes a browser router for navigation and then puts the rest of the app inside
 root.render(
   <BrowserRouter>
     <App/>


### PR DESCRIPTION
Added error handling for failed logins, failed api actions, web player requests, and messages. Updated the session management and websocket connection to be handled in the app.js file. User will stay logged in across screens and dashboard will be greyed out if not logged in.

To test this along with the error-handling branch in API, modify the API code so that certain requests fail.
To see login error handling, change a check in the callback endpoint like the state check. There should be red text on the login page detailing the error.
To see websocket error handling, modify the message type or status code check in the websocket endpoint. A message should be shown in the chat and an error should be logged in the console.